### PR TITLE
feat(GH-1): :sparkles: init functionailty with --copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ go.work.sum
 
 # env file
 .env
+.envrc
+
+bin

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: build run clean
+
+build:
+	go build -o bin/lmdiff .
+
+run: build
+	./bin/lmdiff --branch main
+
+clean:
+	rm -f bin/lmdiff

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
-# lmdiff
-Package changes from a Pull Request Along with the Originals, and Generate a Prompt for an LLM for Precision and Correctness
+# 🔍 lmdiff
+
+Package changes from a Pull Request along with the originals, and generate a prompt for an LLM for precision and correctness.
+
+## Features
+
+- Detailed comparison of modified files
+- Generate informative prompts for AI models
+
+## Usage
+
+Instructions on how to use the lmdiff package will go here.

--- a/main.go
+++ b/main.go
@@ -1,0 +1,132 @@
+/**
+ * @file main.go
+ * @description
+ * This is the main entry point for the Go application that packages git diff changes and original file contents
+ * from a specified remote branch into an LLM reasoning prompt. The application reads the git diff and the content of
+ * the files as they exist in the remote branch, constructs a prompt, and outputs it to stdout.
+ *
+ * Key Features:
+ * - Parses command line argument for branch name (default is "main")
+ * - Retrieves git diff using 'git diff' command
+ * - Retrieves list of changed files using 'git diff --name-only'
+ * - For each changed file, retrieves the original file content from the specified branch using 'git show'
+ * - Constructs an LLM reasoning prompt including overall diff and original file contents
+ * - Outputs the prompt for further assessment by a large language model
+ *
+ * @dependencies
+ * - os/exec: to execute git commands
+ * - flag: to parse command line arguments
+ * - fmt, bytes, strings, log: for various utilities and error handling
+ *
+ * @notes
+ * - Assumes that git is installed and that the application is run within a valid git repository.
+ * - If a file does not exist in the specified branch, a warning is logged and a placeholder message is used.
+ * - Error handling is implemented to gracefully handle command execution failures.
+ */
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os/exec"
+
+	"github.com/jamesonstone/lmdiff/pkg/diff"
+	"github.com/jamesonstone/lmdiff/pkg/prompt"
+)
+
+func main() {
+	branch := flag.String("branch", "main", "The branch name to compare changes with (default: main)")
+	copyFlag := flag.Bool("copy", false, "Automatically copy the prompt output to the clipboard")
+	shortCopyFlag := flag.Bool("c", false, "Automatically copy the prompt output to the clipboard (shorthand)")
+	includeUntrackedFlag := flag.Bool("include-untracked", true, "Include untracked files in the analysis (default: true)")
+	flag.Parse()
+
+	// Get the git diff relative to the specified branch.
+	gitDiff, err := diff.GetGitDiff(*branch)
+	if err != nil {
+		log.Fatalf("Failed to get git diff: %v", err)
+	}
+
+	// Get the list of changed (including added) files compared to the specified branch.
+	changedFiles, err := diff.GetChangedFiles(*branch, *includeUntrackedFlag)
+	if err != nil {
+		log.Fatalf("Failed to get list of changed files: %v", err)
+	}
+
+	// Map to hold original file contents for each changed file.
+	originalFiles := make(map[string]string)
+
+	// Process each file in the changedFiles list
+	for _, file := range changedFiles {
+		if file == "" {
+			continue
+		}
+
+		// Check if this is a directory
+		isDir, err := diff.IsDirectory(file)
+		if err != nil {
+			log.Printf("Warning: could not determine if %s is a directory: %v", file, err)
+			continue
+		}
+
+		if isDir {
+			// If it's a directory, get all files inside it
+			dirFiles, err := diff.GetAllFilesInDirectory(file)
+			if err != nil {
+				log.Printf("Warning: could not read directory %s: %v", file, err)
+				continue
+			}
+
+			// Process each file in the directory
+			for _, dirFile := range dirFiles {
+				content := processFile(dirFile, *branch)
+				originalFiles[dirFile] = content
+			}
+		} else {
+			// It's a regular file
+			content := processFile(file, *branch)
+			originalFiles[file] = content
+		}
+	}
+
+	// Construct the final prompt.
+	promptText := prompt.ConstructLLMPrompt(gitDiff, changedFiles, originalFiles)
+
+	// Output the constructed prompt.
+	fmt.Println(promptText)
+
+	// If --copy or -c flag is set, copy the prompt output to the clipboard using pbcopy.
+	shouldCopy := *copyFlag || *shortCopyFlag
+	if shouldCopy {
+		cmd := exec.Command("pbcopy")
+		in, err := cmd.StdinPipe()
+		if err != nil {
+			log.Fatalf("Failed to get stdin pipe for pbcopy: %v", err)
+		}
+		if err := cmd.Start(); err != nil {
+			log.Fatalf("Failed to start pbcopy: %v", err)
+		}
+		in.Write([]byte(promptText))
+		in.Close()
+		cmd.Wait()
+		fmt.Println("Prompt copied to clipboard.")
+	}
+}
+
+// processFile attempts to get the content of a file from either the branch or locally
+func processFile(file string, branch string) string {
+	content, err := diff.GetFileContent(branch, file)
+	if err != nil {
+		// For new files not present in the remote branch, read from local filesystem.
+		localContent, err2 := diff.GetLocalFileContent(file)
+		if err2 != nil {
+			log.Printf("Warning: cannot retrieve content for %s: %v", file, err2)
+			return "Error retrieving file content."
+		} else {
+			return localContent
+		}
+	}
+	return content
+}

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -1,0 +1,132 @@
+package diff
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// GetGitDiff retrieves the git diff against the specified branch.
+func GetGitDiff(branch string) (string, error) {
+	cmd := exec.Command("git", "diff", branch)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("error executing git diff: %v, %s", err, stderr.String())
+	}
+	return out.String(), nil
+}
+
+// GetChangedFiles returns a slice of filenames that have been changed or added compared to the specified branch.
+// If includeUntracked is true, it also includes untracked files.
+func GetChangedFiles(branch string, includeUntracked bool) ([]string, error) {
+	// Get tracked files with changes
+	cmd := exec.Command("git", "diff", "--name-only", branch)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return nil, fmt.Errorf("error getting changed files: %v, %s", err, stderr.String())
+	}
+	files := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(files) == 1 && files[0] == "" {
+		files = []string{}
+	}
+
+	// If includeUntracked is true, also add untracked files
+	if includeUntracked {
+		untrackedFiles, err := GetUntrackedFiles()
+		if err != nil {
+			return nil, fmt.Errorf("error getting untracked files: %v", err)
+		}
+		files = append(files, untrackedFiles...)
+	}
+
+	return files, nil
+}
+
+// GetUntrackedFiles returns a slice of all untracked files, including files in untracked directories.
+func GetUntrackedFiles() ([]string, error) {
+	// Get all untracked files, including those in untracked directories
+	cmd := exec.Command("git", "ls-files", "--others", "--exclude-standard")
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return nil, fmt.Errorf("error getting untracked files: %v, %s", err, stderr.String())
+	}
+
+	files := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(files) == 1 && files[0] == "" {
+		return []string{}, nil
+	}
+
+	return files, nil
+}
+
+// GetFileContent retrieves the content of a file from the specified branch using git show.
+func GetFileContent(branch, filename string) (string, error) {
+	cmd := exec.Command("git", "show", fmt.Sprintf("%s:%s", branch, filename))
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("error getting file content for %s from branch %s: %v, %s", filename, branch, err, stderr.String())
+	}
+	return out.String(), nil
+}
+
+// GetLocalFileContent retrieves the content of a file from the local filesystem.
+func GetLocalFileContent(filename string) (string, error) {
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		return "", fmt.Errorf("error reading local file %s: %v", filename, err)
+	}
+	return string(content), nil
+}
+
+// IsDirectory checks if a given path is a directory
+func IsDirectory(path string) (bool, error) {
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return false, err
+	}
+	return fileInfo.IsDir(), nil
+}
+
+// GetAllFilesInDirectory recursively gets all files in a directory
+func GetAllFilesInDirectory(dirPath string) ([]string, error) {
+	var files []string
+
+	err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip .git directory
+		if info.IsDir() && info.Name() == ".git" {
+			return filepath.SkipDir
+		}
+
+		// Only add files, not directories
+		if !info.IsDir() {
+			files = append(files, path)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("error walking directory %s: %v", dirPath, err)
+	}
+
+	return files, nil
+}

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -1,0 +1,43 @@
+package prompt
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ConstructLLMPrompt creates an XML formatted LLM prompt with the git diff and original file contents.
+// It now includes all changed and added files and instructs to review best practices for all files.
+func ConstructLLMPrompt(diff string, changedFiles []string, files map[string]string) string {
+	var promptBuilder strings.Builder
+
+	promptBuilder.WriteString("<prompt>\n")
+	promptBuilder.WriteString(". <description>")
+	promptBuilder.WriteString("Please analyze the git diff changes. Review the best practices of all files, including new files. Please use KISS+YAGNI+DRY+SOLID principles.")
+	promptBuilder.WriteString("Assess the new changes against existing files, suggest improvements, and ask clarifying questions if needed. Complete your review by providing a summary of the changes in paragraph form followed by a bulleted list of suggested changes.")
+	promptBuilder.WriteString("</description>\n")
+	promptBuilder.WriteString("  <changedFiles>\n")
+	for _, filename := range changedFiles {
+		if strings.TrimSpace(filename) == "" {
+			continue
+		}
+		promptBuilder.WriteString(fmt.Sprintf("    <file name=\"%s\"/>\n", filename))
+	}
+	promptBuilder.WriteString("  </changedFiles>\n")
+	promptBuilder.WriteString("  <files>\n")
+	for filename, content := range files {
+		promptBuilder.WriteString(fmt.Sprintf("    <file name=\"%s\">\n", filename))
+		promptBuilder.WriteString("      <![CDATA[\n")
+		promptBuilder.WriteString(content)
+		promptBuilder.WriteString("      ]]>\n")
+		promptBuilder.WriteString("    </file>\n")
+	}
+	promptBuilder.WriteString("  </files>\n")
+	promptBuilder.WriteString("  <gitDiff>\n")
+	promptBuilder.WriteString("    <![CDATA[\n")
+	promptBuilder.WriteString(diff)
+	promptBuilder.WriteString("    ]]>\n")
+	promptBuilder.WriteString("  </gitDiff>\n")
+	promptBuilder.WriteString("</prompt>\n")
+
+	return promptBuilder.String()
+}


### PR DESCRIPTION
## Description

- feat(GH-1): :sparkles: init functionailty with --copy

## How to Test:

1. `make build`
2. `./bin/lmdiff --copy`
3. Copy directly (without additional prompt) into your chat tool of choice. 
4. Analyze outcome

## Ticket

GH-1


## Partial Example output from 03-mini

"""🔍 Summary: The changes enhance project documentation and configuration while maintaining overall clarity and modularity. The updates in the .gitignore and README.md improve project hygiene and usability, and the Go source files generally follow best practices (KISS, YAGNI, DRY, SOLID). However, there are opportunities to refine aspects such as directory management in the Makefile, code reuse in the diff package, and further clarification in error handling and documentation. Would you like more detail on any specific area?

Suggested Changes:
	•	.gitignore:
	•	Consider using a trailing slash (e.g., bin/) to explicitly denote a directory.
	•	README.md:
	•	Expand with detailed usage instructions, installation steps, and possibly add sections for license and contributing guidelines.
	•	Makefile:
	•	Add a step (e.g., mkdir -p bin) in the build rule to ensure the output directory exists before compiling.
	•	Consider adding rules for running tests if applicable.
	•	main.go:
	•	Evaluate whether the processFile function should be refactored into a dedicated utility or helper module.
	•	Enhance error messages for more context and consider edge-case handling (e.g., binary file handling).
	•	pkg/diff/diff.go:
	•	Abstract repeated command execution logic (using exec.Command) into a helper function to reduce duplication (DRY).
	•	Optionally add timeout or context management to the command executions for robustness.
	•	pkg/prompt/prompt.go:
	•	The XML construction is clear, but you might further modularize the CDATA section writing if the prompt structure evolves."""